### PR TITLE
feat(enum): initial support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ redis = "0.21.5"
 quote = "1.0.10"
 syn = {version = "1.0", features = ["extra-traits"]}
 serde = { version = "1.0", features = ["derive"] }
+heck = "0.4.1"
 
 [lib]
 proc-macro = true

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,21 +1,43 @@
+use std::str::FromStr;
+
 use redis::Commands;
 use redis_derive::{FromRedisValue, ToRedisArgs};
 
 #[derive(FromRedisValue, ToRedisArgs, Debug)]
+enum Color {
+    Red,
+    Green,
+}
+
+impl FromStr for Color {
+    type Err = Box<dyn std::error::Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "Red" => Color::Red,
+            "Green" => Color::Green,
+            v => panic!("{v} is not valid varient"),
+        })
+    }
+}
+
+#[derive(FromRedisValue, ToRedisArgs, Debug)]
 struct MySuperCoolStruct {
-    first_field : String,
-    second_field : Option<i64>,
-    third_field : Vec<String>
+    first_field: String,
+    second_field: Option<i64>,
+    third_field: Vec<String>,
+    color: Color,
 }
 
 fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/")?;
     let mut con = client.get_connection()?;
 
-    let test1 = MySuperCoolStruct{
-        first_field : "Hello World".to_owned(),
-        second_field : Some(42),
-        third_field : vec!["abc".to_owned(), "cba".to_owned()]
+    let test1 = MySuperCoolStruct {
+        first_field: "Hello World".to_owned(),
+        second_field: Some(42),
+        third_field: vec!["abc".to_owned(), "cba".to_owned()],
+        color: Color::Red,
     };
 
     let _ = redis::cmd("HSET")
@@ -23,7 +45,7 @@ fn main() -> redis::RedisResult<()> {
         .arg(&test1)
         .query(&mut con)?;
 
-    let db_test1 : MySuperCoolStruct = con.hgetall("test1")?;
+    let db_test1: MySuperCoolStruct = con.hgetall("test1")?;
 
     println!("send : {:#?}, got : {:#?}", test1, db_test1);
     Ok(())

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use redis::Commands;
 use redis_derive::{FromRedisValue, ToRedisArgs};
 
@@ -7,18 +5,6 @@ use redis_derive::{FromRedisValue, ToRedisArgs};
 enum Color {
     Red,
     Green,
-}
-
-impl FromStr for Color {
-    type Err = Box<dyn std::error::Error>;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "Red" => Color::Red,
-            "Green" => Color::Green,
-            v => panic!("{v} is not valid varient"),
-        })
-    }
 }
 
 #[derive(FromRedisValue, ToRedisArgs, Debug)]

--- a/src/data_enum.rs
+++ b/src/data_enum.rs
@@ -4,7 +4,7 @@ use quote::quote;
 use syn::{DataEnum, Fields, Ident};
 
 impl DeriveToRedisArgs for DataEnum {
-    fn derive_to_redis(&self, type_ident : Ident) -> proc_macro::TokenStream {
+    fn derive_to_redis(&self, type_ident: Ident) -> proc_macro::TokenStream {
         match self.variants {
             _ => todo!(),
         }

--- a/src/data_enum.rs
+++ b/src/data_enum.rs
@@ -5,8 +5,73 @@ use syn::{DataEnum, Fields, Ident};
 
 impl DeriveToRedisArgs for DataEnum {
     fn derive_to_redis(&self, type_ident: Ident) -> proc_macro::TokenStream {
-        match self.variants {
-            _ => todo!(),
+        let is_unit = self.variants.iter().all(|v| v.fields == Fields::Unit);
+        if !is_unit {
+            panic!("Only Enums without fields are supported");
         }
+
+        let variant_names = self.variants.iter().map(|variant| &variant.ident);
+
+        let match_arms = variant_names.map(|variant_name| {
+            quote! {
+                #type_ident::#variant_name => {
+                    out.write_arg(stringify!(#variant_name).as_bytes());
+                }
+            }
+        });
+
+        quote! {
+            impl redis::ToRedisArgs for #type_ident {
+                fn write_redis_args<W: ?Sized + redis::RedisWrite>(&self, out: &mut W) {
+                    match self { #(#match_arms),* }
+                }
+            }
+        }
+        .into()
+    }
+}
+
+impl DeriveFromRedisArgs for DataEnum {
+    fn derive_from_redis(&self, type_ident: Ident) -> proc_macro::TokenStream {
+        let is_unit = self.variants.iter().all(|v| v.fields == Fields::Unit);
+        if !is_unit {
+            panic!("Only Enums without fields are supported");
+        }
+
+        let match_arms = self.variants.iter().map(|variant| {
+            let variant_name = &variant.ident;
+            quote! {
+                stringify!(#variant_name) => Ok(#type_ident::#variant_name),
+            }
+        });
+
+        let variants_str = self
+            .variants
+            .iter()
+            .map(|variant| variant.ident.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        quote! {
+            impl redis::FromRedisValue for #type_ident {
+                fn from_redis_value(v: &redis::Value) -> Result<Self, redis::RedisError> {
+                    match v {
+                        redis::Value::Data(s) => match std::str::from_utf8(&s[..])? {
+                            #(#match_arms)*
+                            v => Err(redis::RedisError::from((
+                                redis::ErrorKind::TypeError,
+                                "Invalid enum variant:",
+                                format!("{}, Expected one of: {}", v, #variants_str),
+                            ))),
+                        },
+                        v => Err(redis::RedisError::from((
+                            redis::ErrorKind::TypeError,
+                            "Expected Redis string, got:", format!("{:?}", v)
+                        ))),
+                    }
+                }
+            }
+        }
+        .into()
     }
 }

--- a/src/data_struct.rs
+++ b/src/data_struct.rs
@@ -1,9 +1,14 @@
 use super::{DeriveFromRedisArgs, DeriveToRedisArgs};
+use crate::util::ParsedAttributeMap;
 use quote::quote;
 use syn::{DataStruct, Fields, Ident};
 
 impl DeriveToRedisArgs for DataStruct {
-    fn derive_to_redis(&self, type_ident: Ident) -> proc_macro::TokenStream {
+    fn derive_to_redis(
+        &self,
+        type_ident: Ident,
+        _attrs: ParsedAttributeMap,
+    ) -> proc_macro::TokenStream {
         match &self.fields {
             Fields::Named(fields_named) => {
                 let (stringified_idents, idents): (Vec<String>, Vec<&Ident>) = fields_named
@@ -77,7 +82,11 @@ impl DeriveToRedisArgs for DataStruct {
 }
 
 impl DeriveFromRedisArgs for DataStruct {
-    fn derive_from_redis(&self, type_ident: Ident) -> proc_macro::TokenStream {
+    fn derive_from_redis(
+        &self,
+        type_ident: Ident,
+        _attrs: ParsedAttributeMap,
+    ) -> proc_macro::TokenStream {
         match &self.fields {
             Fields::Named(fields_named) => {
                 let (stringified_idents, idents): (Vec<String>, Vec<&Ident>) = fields_named
@@ -201,4 +210,3 @@ impl DeriveFromRedisArgs for DataStruct {
         }
     }
 }
-

--- a/src/data_struct.rs
+++ b/src/data_struct.rs
@@ -1,5 +1,4 @@
 use super::{DeriveFromRedisArgs, DeriveToRedisArgs};
-
 use quote::quote;
 use syn::{DataStruct, Fields, Ident};
 
@@ -41,10 +40,11 @@ impl DeriveToRedisArgs for DataStruct {
                 }.into()
             }
             Fields::Unnamed(fields_unnamed) => {
-                let (stringified_idents, idents) : (Vec<String>, Vec<usize>) = (0..fields_unnamed.unnamed.len())
-                    .into_iter()
-                    .map(|index| (index.to_string(), index))
-                    .unzip();
+                let (stringified_idents, idents): (Vec<String>, Vec<usize>) =
+                    (0..fields_unnamed.unnamed.len())
+                        .into_iter()
+                        .map(|index| (index.to_string(), index))
+                        .unzip();
                 quote!{
                     impl redis::ToRedisArgs for #type_ident {
                         fn write_redis_args<W : ?Sized + redis::RedisWrite>(&self, out: &mut W) {
@@ -77,7 +77,7 @@ impl DeriveToRedisArgs for DataStruct {
 }
 
 impl DeriveFromRedisArgs for DataStruct {
-    fn derive_from_redis(&self, type_ident : Ident) -> proc_macro::TokenStream {
+    fn derive_from_redis(&self, type_ident: Ident) -> proc_macro::TokenStream {
         match &self.fields {
             Fields::Named(fields_named) => {
                 let (stringified_idents, idents): (Vec<String>, Vec<&Ident>) = fields_named
@@ -119,7 +119,7 @@ impl DeriveFromRedisArgs for DataStruct {
                                                 fields_hashmap.insert(full_identifier, values[1].clone());
                                             }
                                         }
-                                    }   
+                                    }
                                     Ok(Self {
                                         #(#idents: redis::from_redis_value(
                                                 fields_hashmap.get(
@@ -131,19 +131,20 @@ impl DeriveFromRedisArgs for DataStruct {
                                     })
                                 },
                                 _ => Err(redis::RedisError::from((
-                                    redis::ErrorKind::TypeError, 
+                                    redis::ErrorKind::TypeError,
                                     "the data returned from the redis database was not in the bulk data format or the length of the bulk data is not devisable by two"))
                                 )
                             }
                         }
                     }
                 }.into()
-            },
+            }
             Fields::Unnamed(fields_unnamed) => {
-                let (stringified_idents, idents) : (Vec<String>, Vec<usize>) = (0..fields_unnamed.unnamed.len())
-                    .into_iter()
-                    .map(|index| (index.to_string(), index))
-                    .unzip();
+                let (stringified_idents, idents): (Vec<String>, Vec<usize>) =
+                    (0..fields_unnamed.unnamed.len())
+                        .into_iter()
+                        .map(|index| (index.to_string(), index))
+                        .unzip();
                 quote! {
                     impl redis::FromRedisValue for #type_ident {
                         fn from_redis_value(v: &redis::Value) -> redis::RedisResult<Self> {
@@ -171,7 +172,7 @@ impl DeriveFromRedisArgs for DataStruct {
                                                 fields_hashmap.insert(full_identifier, values[1].clone());
                                             }
                                         }
-                                    }   
+                                    }
                                     Ok(Self {
                                         #(
                                             #idents: redis::from_redis_value(fields_hashmap.get(#stringified_idents)
@@ -181,21 +182,23 @@ impl DeriveFromRedisArgs for DataStruct {
                                     })
                                 },
                                 _ => Err(redis::RedisError::from((
-                                    redis::ErrorKind::TypeError, 
+                                    redis::ErrorKind::TypeError,
                                     "the data returned from the redis database was not in the bulk data format or the length of the bulk data is not devisable by two"))
                                 )
                             }
                         }
                     }
                 }.into()
-            },
+            }
             Fields::Unit => quote! {
                 impl redis::FromRedisValue for #type_ident {
                     fn from_redis_value(v: &redis::Value) -> redis::RedisResult<Self> {
                         #type_ident{}
                     }
                 }
-            }.into(),
+            }
+            .into(),
         }
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,40 +48,44 @@ use syn::{
     Data::{Enum, Struct, Union},
     DeriveInput, Ident,
 };
+use util::ParsedAttributeMap;
 
 mod data_enum;
 mod data_struct;
+mod util;
 
-#[proc_macro_derive(ToRedisArgs)]
+#[proc_macro_derive(ToRedisArgs, attributes(redis))]
 /// This Derive Macro is responsible for Implementing the [ToRedisArgs](redis::ToRedisArgs) trait for the decorated struct.
 pub fn to_redis_args(tokenstream: TokenStream) -> TokenStream {
     let abstract_syntax_tree = parse_macro_input!(tokenstream as DeriveInput);
     let type_identifier = abstract_syntax_tree.ident;
+    let attr_map = util::parse_attributes(&abstract_syntax_tree.attrs);
 
     match abstract_syntax_tree.data {
-        Struct(data_struct) => data_struct.derive_to_redis(type_identifier),
-        Enum(data_enum) => data_enum.derive_to_redis(type_identifier),
+        Struct(data_struct) => data_struct.derive_to_redis(type_identifier, attr_map),
+        Enum(data_enum) => data_enum.derive_to_redis(type_identifier, attr_map),
         Union(_) => todo!(),
     }
 }
 
-#[proc_macro_derive(FromRedisValue)]
+#[proc_macro_derive(FromRedisValue, attributes(redis))]
 /// This Derive Macro is responsible for Implementing the [ToRedisArgs](redis::FromRedisValue) trait for the decorated struct.
 pub fn from_redis_value(tokenstream: TokenStream) -> TokenStream {
     let abstract_syntax_tree = parse_macro_input!(tokenstream as DeriveInput);
     let type_identifier = abstract_syntax_tree.ident;
+    let attr_map = util::parse_attributes(&abstract_syntax_tree.attrs);
 
     match abstract_syntax_tree.data {
-        Struct(data_struct) => data_struct.derive_from_redis(type_identifier),
-        Enum(data_enum) => data_enum.derive_from_redis(type_identifier),
+        Struct(data_struct) => data_struct.derive_from_redis(type_identifier, attr_map),
+        Enum(data_enum) => data_enum.derive_from_redis(type_identifier, attr_map),
         Union(_) => todo!(),
     }
 }
 
 trait DeriveToRedisArgs {
-    fn derive_to_redis(&self, type_ident: Ident) -> TokenStream;
+    fn derive_to_redis(&self, type_ident: Ident, attrs: ParsedAttributeMap) -> TokenStream;
 }
 
 trait DeriveFromRedisArgs {
-    fn derive_from_redis(&self, type_ident: Ident) -> TokenStream;
+    fn derive_from_redis(&self, type_ident: Ident, attrs: ParsedAttributeMap) -> TokenStream;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,24 @@ mod data_struct;
 mod util;
 
 #[proc_macro_derive(ToRedisArgs, attributes(redis))]
-/// This Derive Macro is responsible for Implementing the [ToRedisArgs](redis::ToRedisArgs) trait for the decorated struct.
+/// This macro implements the [ToRedisArgs](redis::ToRedisArgs) trait for a given struct or enum.
+/// It generates code that serializes the fields of the struct or the variants
+/// of the enum to Redis arguments.
+///
+/// # Attributes
+///
+/// This macro also supports the following attribute on the entire struct or enum:
+///
+/// - `redis(rename_all = "...")`: This attribute specifies a rule for transforming the variants to Redis argument names. (only enums supported for now)
+///
+///   The possible values are:
+///   - `"lowercase"`: The name is converted to lowercase.
+///   - `"UPPERCASE"`: The name is converted to uppercase.
+///   - `"PascalCase"`: The name is converted to PascalCase.
+///   - `"camelCase"`: The name is converted to camelCase.
+///   - `"snake_case"`: The name is converted to snake_case.
+///   - `"kebab-case"`: The name is converted to kebab-case.
+///
 pub fn to_redis_args(tokenstream: TokenStream) -> TokenStream {
     let abstract_syntax_tree = parse_macro_input!(tokenstream as DeriveInput);
     let type_identifier = abstract_syntax_tree.ident;
@@ -69,7 +86,24 @@ pub fn to_redis_args(tokenstream: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(FromRedisValue, attributes(redis))]
-/// This Derive Macro is responsible for Implementing the [ToRedisArgs](redis::FromRedisValue) trait for the decorated struct.
+/// This macro implements the [FromRedisValue](redis::FromRedisValue) trait for a given struct or enum.
+/// It generates code that deserialize the fields of the struct or the variants
+/// of the enum from [Value](redis::Value)
+///
+/// # Attributes
+///
+/// This macro also supports the following attribute on the entire struct or enum:
+///
+/// - `redis(rename_all = "...")`: This attribute specifies a rule for parsing variant (only enums supported for now) .
+///
+///   The possible values are:
+///   - `"lowercase"`: Generate variant from lowercase.
+///   - `"UPPERCASE"`: Generate variant from uppercase.
+///   - `"PascalCase"`: Generate variant from PascalCase.
+///   - `"camelCase"`: Generate variant from camelCase.
+///   - `"snake_case"`: Generate variant from snake_case.
+///   - `"kebab-case"`: Generate variant from kebab-case.
+///
 pub fn from_redis_value(tokenstream: TokenStream) -> TokenStream {
     let abstract_syntax_tree = parse_macro_input!(tokenstream as DeriveInput);
     let type_identifier = abstract_syntax_tree.ident;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub fn to_redis_args(tokenstream: TokenStream) -> TokenStream {
 
     match abstract_syntax_tree.data {
         Struct(data_struct) => data_struct.derive_to_redis(type_identifier),
-        Enum(_) => todo!(),
+        Enum(data_enum) => data_enum.derive_to_redis(type_identifier),
         Union(_) => todo!(),
     }
 }
@@ -73,8 +73,8 @@ pub fn from_redis_value(tokenstream: TokenStream) -> TokenStream {
 
     match abstract_syntax_tree.data {
         Struct(data_struct) => data_struct.derive_from_redis(type_identifier),
-        syn::Data::Enum(_) => todo!(),
-        syn::Data::Union(_) => todo!(),
+        Enum(data_enum) => data_enum.derive_from_redis(type_identifier),
+        Union(_) => todo!(),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,65 +1,60 @@
 /*!
-This crate implements the [FromRedisValue](redis::FromRedisValue) and [ToRedisArgs](redis::ToRedisArgs) traits from 
-  for any struct, 
- this allows a seaming less type conversion between rust structs and Redis hash sets. 
- 
- This is more beneficial than JSON encoding the struct and storing the result in a Redis key because when saving as a Redis hash set, 
- sorting algorithms can be performed without having to move data out of the database. 
- 
+This crate implements the [FromRedisValue](redis::FromRedisValue) and [ToRedisArgs](redis::ToRedisArgs) traits from
+  for any struct,
+ this allows a seaming less type conversion between rust structs and Redis hash sets.
+
+ This is more beneficial than JSON encoding the struct and storing the result in a Redis key because when saving as a Redis hash set,
+ sorting algorithms can be performed without having to move data out of the database.
+
  There is also the benefit of being able to retrieve just one value of the struct in the database.
- 
+
  ## Example
  ```
  use redis::Commands;
  use redis_derive::{FromRedisValue, ToRedisArgs};
- 
+
  #[derive(FromRedisValue, ToRedisArgs, Debug)]
  struct MySuperCoolStruct {
      first_field : String,
      second_field : Option<i64>,
      third_field : Vec<String>
  }
- 
+
  fn main() -> redis::RedisResult<()> {
      let client = redis::Client::open("redis://127.0.0.1/")?;
      let mut con = client.get_connection()?;
- 
+
      let test1 = MySuperCoolStruct{
          first_field : "Hello World".to_owned(),
          second_field : Some(42),
          third_field : vec!["abc".to_owned(), "cba".to_owned()]
      };
- 
+
      let _ = redis::cmd("HSET")
          .arg("test1")
          .arg(&test1)
          .query(&mut con)?;
- 
+
      let db_test1 : MySuperCoolStruct = con.hgetall("test1")?;
- 
+
      println!("send : {:#?}, got : {:#?}", test1, db_test1);
      Ok(())
  }
  ```
-*/ 
+*/
 use proc_macro::TokenStream;
 use syn::{
-    parse_macro_input, 
-    DeriveInput, 
-    Data::{
-        Struct,
-        Enum,
-        Union
-    },
-    Ident
+    parse_macro_input,
+    Data::{Enum, Struct, Union},
+    DeriveInput, Ident,
 };
 
-mod data_struct;
 mod data_enum;
+mod data_struct;
 
 #[proc_macro_derive(ToRedisArgs)]
 /// This Derive Macro is responsible for Implementing the [ToRedisArgs](redis::ToRedisArgs) trait for the decorated struct.
-pub fn to_redis_args(tokenstream : TokenStream) -> TokenStream {
+pub fn to_redis_args(tokenstream: TokenStream) -> TokenStream {
     let abstract_syntax_tree = parse_macro_input!(tokenstream as DeriveInput);
     let type_identifier = abstract_syntax_tree.ident;
 
@@ -70,26 +65,23 @@ pub fn to_redis_args(tokenstream : TokenStream) -> TokenStream {
     }
 }
 
-
 #[proc_macro_derive(FromRedisValue)]
 /// This Derive Macro is responsible for Implementing the [ToRedisArgs](redis::FromRedisValue) trait for the decorated struct.
-pub fn from_redis_value(tokenstream : TokenStream) -> TokenStream {
+pub fn from_redis_value(tokenstream: TokenStream) -> TokenStream {
     let abstract_syntax_tree = parse_macro_input!(tokenstream as DeriveInput);
     let type_identifier = abstract_syntax_tree.ident;
 
     match abstract_syntax_tree.data {
-        Struct(data_struct) => {
-            data_struct.derive_from_redis(type_identifier)
-        },
+        Struct(data_struct) => data_struct.derive_from_redis(type_identifier),
         syn::Data::Enum(_) => todo!(),
         syn::Data::Union(_) => todo!(),
     }
 }
 
 trait DeriveToRedisArgs {
-    fn derive_to_redis(&self, type_ident : Ident) -> TokenStream;
+    fn derive_to_redis(&self, type_ident: Ident) -> TokenStream;
 }
 
 trait DeriveFromRedisArgs {
-    fn derive_from_redis(&self, type_ident : Ident) -> TokenStream;
+    fn derive_from_redis(&self, type_ident: Ident) -> TokenStream;
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,51 @@
+use heck::{ToKebabCase, ToLowerCamelCase, ToPascalCase, ToSnakeCase};
+use std::collections::HashMap;
+use syn::{Attribute, Meta, NestedMeta};
+
+pub type ParsedAttributeMap = HashMap<String, String>;
+
+/// Parses the Redis attributes in the given list of attributes, and returns a
+/// mapping of attribute names to their string values.
+pub fn parse_attributes(attributes: &[Attribute]) -> ParsedAttributeMap {
+    let mut attr_map = HashMap::new();
+    for attribute in attributes {
+        if !attribute.path.is_ident("redis") {
+            continue;
+        }
+
+        if let Ok(Meta::List(meta)) = attribute.parse_meta() {
+            if meta.path.is_ident("redis") {
+                for nested_meta in meta.nested {
+                    if let NestedMeta::Meta(Meta::NameValue(name_value)) = nested_meta {
+                        let attr_name = name_value
+                            .path
+                            .get_ident()
+                            .expect("Attribute name expected")
+                            .to_string();
+                        let attr_value = match &name_value.lit {
+                            syn::Lit::Str(lit_str) => lit_str.value(),
+                            _ => panic!("Attribute value must be a string literal"),
+                        };
+                        attr_map.insert(attr_name, attr_value);
+                    }
+                }
+            }
+        }
+    }
+    attr_map
+}
+
+/// Transforms a variant value into the desired case style based on the provided `rename_all` option.
+pub fn transform_variant(variant_value: &str, rename_all: Option<&str>) -> String {
+    let renamed = rename_all.map(|rule| match rule {
+        "lowercase" => variant_value.to_lowercase(),
+        "UPPERCASE" => variant_value.to_uppercase(),
+        "PascalCase" => variant_value.to_pascal_case(),
+        "camelCase" => variant_value.to_lower_camel_case(),
+        "snake_case" => variant_value.to_snake_case(),
+        "kebab-case" => variant_value.to_kebab_case(),
+        _ => panic!("Invalid rename_all value"),
+    });
+
+    renamed.unwrap_or_else(|| variant_value.to_string())
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -36,6 +36,8 @@ pub fn parse_attributes(attributes: &[Attribute]) -> ParsedAttributeMap {
 }
 
 /// Transforms a variant value into the desired case style based on the provided `rename_all` option.
+///
+/// This function panics if an invalid `rename_all` value is provided.
 pub fn transform_variant(variant_value: &str, rename_all: Option<&str>) -> String {
     let renamed = rename_all.map(|rule| match rule {
         "lowercase" => variant_value.to_lowercase(),


### PR DESCRIPTION
Hey, @michaelvanstraten amazing crate, saved me from writing 80 lines of code for each type I want to use with redis.

I've manged to support enums with no fields. However, when an enum has fields I simply just paniced.

I'm not sure how to support for enum with unamed and named fields, we can only have string type at the end. Let me know if you have any ideas.



