### PR TITLE
update to support resp3 redis 7+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-derive"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 authors = ["Michael van Straten", "kkharji"]
 repository = "https://github.com/kkharji/redis-derive"
@@ -12,11 +12,31 @@ description = "This crate implements the redis::FromRedisValue and redis::ToRedi
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-redis = "0.21.5"
-quote = "1.0.10"
-syn = { version = "1.0", features = ["extra-traits"] }
-heck = "0.4.1"
+# Redis client - minimum 0.32.4 for modern features
+redis = "0.32.4"
+
+# Procedural macro dependencies
+quote = "1.0"
+syn = { version = "2.0", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0"
+
+# String case conversion utilities
+heck = "0.5"
 
 [lib]
 proc-macro = true
 path = "src/lib.rs"
+
+
+# Examples demonstrating redis-derive usage
+[[example]]
+name = "main"
+path = "examples/main.rs"
+
+[[example]]
+name = "enum_branches"
+path = "examples/enum_branches.rs"
+
+[[example]]
+name = "debug_attributes"
+path = "examples/debug_attributes.rs"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,114 @@
+# Redis Derive Examples
+
+This directory contains examples demonstrating the usage of `redis-derive` with different Redis value types and scenarios.
+
+## Prerequisites
+
+- Docker and Docker Compose
+- Rust (latest stable version)
+
+## Quick Start
+
+### 1. Start Redis Server
+
+Start the Redis server using Docker Compose:
+
+```bash
+# From the examples directory
+docker-compose up -d
+```
+
+This will start a Redis 7 server on port 6379 with data persistence.
+
+### 2. Run the Basic Example
+
+```bash
+# From the project root
+cargo run --example main
+```
+
+### 3. Run the Comprehensive Enum Example
+
+```bash
+# From the project root  
+cargo run --example enum_branches
+```
+
+### 4. Clean Up
+
+When you're done testing:
+
+```bash
+# From the examples directory
+docker-compose down
+```
+
+To also remove the data volume:
+
+```bash
+docker-compose down -v
+```
+
+## Examples Overview
+
+### `main.rs`
+Basic example showing struct and enum serialization/deserialization with Redis.
+
+### `enum_branches.rs`
+Comprehensive example that tests all branches of enum deserialization:
+- `BulkString` - Normal stored enum values
+- `SimpleString` - Direct Redis string responses
+- `VerbatimString` - Redis 6+ RESP3 verbatim strings
+- `Nil` - Error handling for nil values
+- Invalid types - Error handling for incompatible types
+
+## Troubleshooting
+
+### Redis Connection Issues
+
+If you get connection errors, make sure Redis is running:
+
+```bash
+# Check if Redis container is running
+docker-compose ps
+
+# Check Redis logs
+docker-compose logs redis
+
+# Test connection manually
+redis-cli ping
+```
+
+### Port Conflicts
+
+If port 6379 is already in use, you can change it in `docker-compose.yml`:
+
+```yaml
+ports:
+  - "6380:6379"  # Use port 6380 instead
+```
+
+Then update your connection string in the examples to use `redis://127.0.0.1:6380/`.
+
+## Redis Features Used
+
+- **RESP2/RESP3 Protocol**: Examples work with both Redis protocol versions
+- **Hash Operations**: Struct serialization uses Redis hashes (HSET/HGET)
+- **String Operations**: Enum serialization uses Redis strings (SET/GET)
+- **Error Handling**: Demonstrates proper error handling for various scenarios
+
+## Development
+
+To add new examples:
+
+1. Create a new `.rs` file in this directory
+2. Add it to the `[[example]]` section in `Cargo.toml`
+3. Make sure it connects to `redis://127.0.0.1:6379/`
+4. Update this README with a description
+
+## Notes
+
+- The Redis container uses Alpine Linux for a smaller image size
+- Data is persisted in a Docker volume named `redis_data`
+- Health checks ensure Redis is ready before examples run
+- Redis 7 is used to support the latest RESP3 features

--- a/examples/debug_attributes.rs
+++ b/examples/debug_attributes.rs
@@ -1,0 +1,103 @@
+use redis::Commands;
+use redis_derive::{FromRedisValue, ToRedisArgs};
+
+// Test enum WITHOUT rename_all
+#[derive(FromRedisValue, ToRedisArgs, Debug, PartialEq)]
+enum StatusNormal {
+    Active,
+    Inactive,
+    Pending,
+}
+
+// Test enum WITH rename_all
+#[derive(FromRedisValue, ToRedisArgs, Debug, PartialEq)]
+#[redis(rename_all = "snake_case")]
+enum StatusSnakeCase {
+    VeryActive,
+    SomewhatInactive,
+    StillPending,
+}
+
+fn main() -> redis::RedisResult<()> {
+    println!("🔍 Debug: Testing Attribute Parsing");
+    println!("===================================");
+
+    let client = redis::Client::open("redis://127.0.0.1:6379/")?;
+    let mut con = client.get_connection()?;
+
+    // Test 1: Normal enum (no rename_all)
+    println!("\n1️⃣ Testing enum WITHOUT rename_all:");
+    let status1 = StatusNormal::Active;
+    let _: () = con.set("status_normal", &status1)?;
+    let stored1: String = con.get("status_normal")?;
+    println!("   ✓ StatusNormal::Active stored as: '{}'", stored1);
+    
+    let status2 = StatusNormal::Inactive;
+    let args = redis::ToRedisArgs::to_redis_args(&status2);
+    let arg_str = String::from_utf8(args[0].clone()).unwrap();
+    println!("   ✓ StatusNormal::Inactive ToRedisArgs: '{}'", arg_str);
+
+    // Test 2: Snake case enum (with rename_all)
+    println!("\n2️⃣ Testing enum WITH rename_all = \"snake_case\":");
+    let status3 = StatusSnakeCase::VeryActive;
+    let _: () = con.set("status_snake", &status3)?;
+    let stored3: String = con.get("status_snake")?;
+    println!("   ✓ StatusSnakeCase::VeryActive stored as: '{}'", stored3);
+    println!("   🔍 Expected: 'very_active' (if rename_all works)");
+    
+    let status4 = StatusSnakeCase::SomewhatInactive;
+    let args = redis::ToRedisArgs::to_redis_args(&status4);
+    let arg_str = String::from_utf8(args[0].clone()).unwrap();
+    println!("   ✓ StatusSnakeCase::SomewhatInactive ToRedisArgs: '{}'", arg_str);
+    println!("   🔍 Expected: 'somewhat_inactive' (if rename_all works)");
+
+    // Test 3: Check if we can deserialize the stored values
+    println!("\n3️⃣ Testing deserialization:");
+    
+    // Try to deserialize the normal enum
+    let retrieved1: StatusNormal = con.get("status_normal")?;
+    println!("   ✓ Retrieved StatusNormal: {:?}", retrieved1);
+    assert_eq!(retrieved1, StatusNormal::Active);
+    
+    // Try to deserialize the snake case enum
+    let retrieved3: StatusSnakeCase = con.get("status_snake")?;
+    println!("   ✓ Retrieved StatusSnakeCase: {:?}", retrieved3);
+    assert_eq!(retrieved3, StatusSnakeCase::VeryActive);
+
+    // Test 4: Manual deserialization tests
+    println!("\n4️⃣ Testing manual Value deserialization:");
+    
+    // Test if the snake case variant accepts snake_case strings
+    let test_value = redis::Value::SimpleString("very_active".to_string());
+    let result: redis::RedisResult<StatusSnakeCase> = redis::FromRedisValue::from_redis_value(&test_value);
+    
+    match result {
+        Ok(val) => {
+            println!("   ✓ 'very_active' successfully deserialized to: {:?}", val);
+            println!("   ✅ rename_all is working for deserialization!");
+        }
+        Err(e) => {
+            println!("   ❌ 'very_active' failed to deserialize: {}", e);
+            println!("   🔍 rename_all might not be working...");
+            
+            // Try with original case
+            let test_value2 = redis::Value::SimpleString("VeryActive".to_string());
+            let result2: redis::RedisResult<StatusSnakeCase> = redis::FromRedisValue::from_redis_value(&test_value2);
+            
+            match result2 {
+                Ok(val) => {
+                    println!("   ✓ 'VeryActive' (original case) deserialized to: {:?}", val);
+                    println!("   ⚠️  rename_all is NOT working - using original enum names");
+                }
+                Err(e2) => {
+                    println!("   ❌ Both 'very_active' and 'VeryActive' failed!");
+                    println!("      Error 1: {}", e);
+                    println!("      Error 2: {}", e2);
+                }
+            }
+        }
+    }
+
+    println!("\n🔍 Debug complete!");
+    Ok(())
+}

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: redis-derive-example
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  redis_data:

--- a/examples/enum_branches.rs
+++ b/examples/enum_branches.rs
@@ -1,0 +1,257 @@
+use redis::Commands;
+use redis_derive::{FromRedisValue, ToRedisArgs};
+
+#[derive(FromRedisValue, ToRedisArgs, Debug, PartialEq)]
+#[redis(rename_all = "snake_case")]
+enum UserRole {
+    Administrator,
+    Moderator,
+    RegularUser,
+    GuestUser,
+}
+
+#[derive(FromRedisValue, ToRedisArgs, Debug, PartialEq)]
+enum Status {
+    Active,
+    Inactive,
+    Pending,
+}
+
+fn main() -> redis::RedisResult<()> {
+    println!("🚀 Redis Derive Enum Branches Example");
+    println!("=====================================");
+
+    let client = redis::Client::open("redis://127.0.0.1:6379/")?;
+    let mut con = client.get_connection()?;
+
+    // Test 1: Normal BulkString case (most common)
+    println!("\n1️⃣  Testing BulkString deserialization (normal case)");
+    test_bulk_string_case(&mut con)?;
+
+    // Test 2: SimpleString case (manual construction)
+    println!("\n2️⃣  Testing SimpleString deserialization");
+    test_simple_string_case()?;
+
+    // Test 3: VerbatimString case (RESP3 feature)
+    println!("\n3️⃣  Testing VerbatimString deserialization");
+    test_verbatim_string_case()?;
+
+    // Test 4: Nil value error case
+    println!("\n4️⃣  Testing Nil value error handling");
+    test_nil_case()?;
+
+    // Test 5: Invalid type error case
+    println!("\n5️⃣  Testing invalid type error handling");
+    test_invalid_type_case()?;
+
+    // Test 6: Invalid UTF-8 error case
+    println!("\n6️⃣  Testing invalid UTF-8 error handling");
+    test_invalid_utf8_case()?;
+
+    // Test 7: Unknown variant error case
+    println!("\n7️⃣  Testing unknown variant error handling");
+    test_unknown_variant_case()?;
+
+    println!("\n✅ All enum deserialization branches tested successfully!");
+    Ok(())
+}
+
+fn test_bulk_string_case(con: &mut redis::Connection) -> redis::RedisResult<()> {
+    // Store an enum value normally - this will be retrieved as BulkString
+    let role = UserRole::Administrator;
+    let _: () = con.set("user_role", &role)?;
+
+    // Retrieve and deserialize - this triggers the BulkString branch
+    let retrieved_role: UserRole = con.get("user_role")?;
+    
+    println!("   ✓ Stored: {:?}", role);
+    println!("   ✓ Retrieved: {:?}", retrieved_role);
+    assert_eq!(role, retrieved_role);
+    println!("   ✓ BulkString deserialization works correctly");
+
+    Ok(())
+}
+
+fn test_simple_string_case() -> redis::RedisResult<()> {
+    // Manually construct a SimpleString value
+    // Use the snake_case version since UserRole has rename_all = "snake_case"
+    let simple_string_value = redis::Value::SimpleString("moderator".to_string());
+    
+    // Deserialize from SimpleString
+    let result: redis::RedisResult<UserRole> = redis::FromRedisValue::from_redis_value(&simple_string_value);
+    
+    match result {
+        Ok(role) => {
+            println!("   ✓ SimpleString 'moderator' deserialized to: {:?}", role);
+            assert_eq!(role, UserRole::Moderator);
+            println!("   ✓ SimpleString deserialization works correctly");
+        }
+        Err(e) => {
+            println!("   ❌ SimpleString deserialization failed: {}", e);
+            return Err(e);
+        }
+    }
+
+    Ok(())
+}
+
+fn test_verbatim_string_case() -> redis::RedisResult<()> {
+    // Manually construct a VerbatimString value (RESP3 feature)
+    let verbatim_value = redis::Value::VerbatimString {
+        format: redis::VerbatimFormat::Text,
+        text: "regular_user".to_string(),
+    };
+    
+    // Deserialize from VerbatimString
+    let result: redis::RedisResult<UserRole> = redis::FromRedisValue::from_redis_value(&verbatim_value);
+    
+    match result {
+        Ok(role) => {
+            println!("   ✓ VerbatimString 'regular_user' deserialized to: {:?}", role);
+            assert_eq!(role, UserRole::RegularUser);
+            println!("   ✓ VerbatimString deserialization works correctly");
+        }
+        Err(e) => {
+            println!("   ❌ VerbatimString deserialization failed: {}", e);
+            return Err(e);
+        }
+    }
+
+    Ok(())
+}
+
+fn test_nil_case() -> redis::RedisResult<()> {
+    // Test deserializing from Nil value
+    let nil_value = redis::Value::Nil;
+    
+    let result: redis::RedisResult<UserRole> = redis::FromRedisValue::from_redis_value(&nil_value);
+    
+    match result {
+        Ok(_) => {
+            println!("   ❌ Expected error but got success!");
+            panic!("Nil deserialization should fail");
+        }
+        Err(e) => {
+            println!("   ✓ Nil value correctly rejected with error: {}", e);
+            println!("   ✓ Nil error handling works correctly");
+        }
+    }
+
+    Ok(())
+}
+
+fn test_invalid_type_case() -> redis::RedisResult<()> {
+    // Test deserializing from incompatible type (Integer)
+    let int_value = redis::Value::Int(42);
+    
+    let result: redis::RedisResult<UserRole> = redis::FromRedisValue::from_redis_value(&int_value);
+    
+    match result {
+        Ok(_) => {
+            println!("   ❌ Expected error but got success!");
+            panic!("Integer deserialization should fail");
+        }
+        Err(e) => {
+            println!("   ✓ Integer value correctly rejected with error: {}", e);
+            println!("   ✓ Invalid type error handling works correctly");
+        }
+    }
+
+    // Test with Array type too
+    let array_value = redis::Value::Array(vec![
+        redis::Value::SimpleString("not".to_string()),
+        redis::Value::SimpleString("an".to_string()),
+        redis::Value::SimpleString("enum".to_string()),
+    ]);
+    
+    let result: redis::RedisResult<Status> = redis::FromRedisValue::from_redis_value(&array_value);
+    
+    match result {
+        Ok(_) => {
+            println!("   ❌ Expected error but got success!");
+            panic!("Array deserialization should fail");
+        }
+        Err(e) => {
+            println!("   ✓ Array value correctly rejected with error: {}", e);
+            println!("   ✓ Array type error handling works correctly");
+        }
+    }
+
+    Ok(())
+}
+
+fn test_invalid_utf8_case() -> redis::RedisResult<()> {
+    // Create invalid UTF-8 bytes
+    let invalid_utf8_bytes = vec![0xFF, 0xFE, 0xFD]; // Invalid UTF-8 sequence
+    let bulk_string_value = redis::Value::BulkString(invalid_utf8_bytes);
+    
+    let result: redis::RedisResult<UserRole> = redis::FromRedisValue::from_redis_value(&bulk_string_value);
+    
+    match result {
+        Ok(_) => {
+            println!("   ❌ Expected UTF-8 error but got success!");
+            panic!("Invalid UTF-8 deserialization should fail");
+        }
+        Err(e) => {
+            println!("   ✓ Invalid UTF-8 correctly rejected with error: {}", e);
+            println!("   ✓ UTF-8 validation works correctly");
+        }
+    }
+
+    Ok(())
+}
+
+fn test_unknown_variant_case() -> redis::RedisResult<()> {
+    // Test with unknown variant name
+    let unknown_variant = redis::Value::SimpleString("super_admin".to_string());
+    
+    let result: redis::RedisResult<UserRole> = redis::FromRedisValue::from_redis_value(&unknown_variant);
+    
+    match result {
+        Ok(_) => {
+            println!("   ❌ Expected unknown variant error but got success!");
+            panic!("Unknown variant deserialization should fail");
+        }
+        Err(e) => {
+            println!("   ✓ Unknown variant 'super_admin' correctly rejected");
+            println!("   ✓ Error message: {}", e);
+            
+            // Check that error message contains valid variants
+            let error_msg = e.to_string();
+            assert!(error_msg.contains("administrator"));
+            assert!(error_msg.contains("moderator"));
+            assert!(error_msg.contains("regular_user"));
+            assert!(error_msg.contains("guest_user"));
+            
+            println!("   ✓ Error message includes valid variants list");
+            println!("   ✓ Unknown variant error handling works correctly");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_enum_variant_names() {
+        // Test that our rename_all = "snake_case" works correctly
+        let admin = UserRole::Administrator;
+        let args = redis::ToRedisArgs::to_redis_args(&admin);
+        assert_eq!(args[0], b"administrator");
+
+        let regular = UserRole::RegularUser;
+        let args = redis::ToRedisArgs::to_redis_args(&regular);
+        assert_eq!(args[0], b"regular_user");
+    }
+
+    #[test]
+    fn test_status_enum_no_rename() {
+        // Test enum without rename_all
+        let active = Status::Active;
+        let args = redis::ToRedisArgs::to_redis_args(&active);
+        assert_eq!(args[0], b"Active");
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,81 +1,222 @@
 # redis-derive
 
-This crate implements the `FromRedisValue`(redis::FromRedisValue) and `ToRedisArgs`(redis::ToRedisArgs) traits from `mitsuhiko / redis-rs`(https://github.com/mitsuhiko/redis-rs) for any struct,
-this allows a seaming less type conversion between rust structs and Redis hash sets.
+## redis-derive
 
-This is more beneficial than JSON encoding the struct and storing the result in a Redis key because when saving as a Redis hash set,
-sorting algorithms can be performed without having to move data out of the database.
+This crate implements the `FromRedisValue`(redis::FromRedisValue) and `ToRedisArgs`(redis::ToRedisArgs) traits
+from `redis-rs`(https://github.com/redis-rs/redis-rs) for any struct or enum.
+
+This allows seamless type conversion between Rust structs and Redis hash sets, which is more beneficial than JSON encoding the struct and storing the result in a Redis key because when saving as a Redis hash set, sorting algorithms can be performed without having to move data out of the database.
 
 There is also the benefit of being able to retrieve just one value of the struct in the database.
 
 Initial development was done by @Michaelvanstraten 🙏🏽.
 
-## Usage and Examples
+### Features
 
-To use this crate at it to your dependencies and import the following to procedural macros.
+- **RESP3 Support**: Native support for Redis 7+ protocol features including VerbatimString
+- **Hash Field Expiration**: Per-field TTL support using Redis 7.4+ HEXPIRE commands
+- **Client-Side Caching**: Automatic cache management with Redis 6+ client caching
+- **Cluster Awareness**: Hash tag generation for Redis Cluster deployments
+- **Flexible Naming**: Support for various case conversion rules (snake_case, kebab-case, etc.)
+- **Comprehensive Error Handling**: Clear error messages for debugging
+- **Performance Optimized**: Efficient serialization with minimal allocations
+
+### Usage and Examples
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+redis-derive = "0.2.0"
+redis = "0.32"
+```
+
+Import the procedural macros:
 
 ```rust
 use redis_derive::{FromRedisValue, ToRedisArgs};
 ```
 
-Now the these Marcos can be used to implement the traits `FromRedisValue`(redis::FromRedisValue) and `ToRedisArgs`(redis::ToRedisArgs) for your decorated struct.
+#### Basic Struct Example
 
-```rust
-#[derive(ToRedisArgs, FromRedisValue)]
-struct MySuperCoolStruct {
-    first_field : String,
-    second_field : Option<i64>,
-    third_field : Vec<String>
-}
-
-```
-These Procedural macros work for any struct in which every field's type also implements `ToRedisArgs`(redis::ToRedisArgs) so this would be allowed:
-```rust
-#[derive(ToRedisArgs, FromRedisVaule)]
-struct MySuperCoolStruct {
-    first_field : String,
-    second_field : Option<i64>,
-    third_field : Vec<String>
-}
-
-#[derive(ToRedisArgs, FromRedisVaule)]
-struct MySecondSuperCoolStruct {
-    fourth_field : String,
-    inner_struct : MySuperCoolStruct
-}
-```
-### Complete Example
 ```rust
 use redis::Commands;
 use redis_derive::{FromRedisValue, ToRedisArgs};
 
-#[derive(FromRedisValue, ToRedisArgs, Debug)]
-struct MySuperCoolStruct {
-    first_field : String,
-    second_field : Option<i64>,
-    third_field : Vec<String>
+#[derive(ToRedisArgs, FromRedisValue, Debug)]
+struct User {
+    id: u64,
+    username: String,
+    email: Option<String>,
+    active: bool,
 }
 
 fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/")?;
     let mut con = client.get_connection()?;
 
-    let test1 = MySuperCoolStruct{
-        first_field : "Hello World".to_owned(),
-        second_field : Some(42),
-        third_field : vec!["abc".to_owned(), "cba".to_owned()]
+    let user = User {
+        id: 12345,
+        username: "john_doe".to_string(),
+        email: Some("john@example.com".to_string()),
+        active: true,
     };
 
-    let _ = redis::cmd("HSET")
-        .arg("test1")
-        .arg(&test1)
-        .query(&mut con)?;
+    // Store individual fields
+    con.hset("user:12345", "id", user.id)?;
+    con.hset("user:12345", "username", &user.username)?;
+    con.hset("user:12345", "email", &user.email)?;
+    con.hset("user:12345", "active", user.active)?;
 
-    let db_test1 : MySuperCoolStruct = con.hgetall("test1")?;
+    // Retrieve the complete struct
+    let retrieved_user: User = con.hgetall("user:12345")?;
+    println!("Retrieved: {:?}", retrieved_user);
 
-    println!("send : {:#?}, got : {:#?}", test1, db_test1);
     Ok(())
 }
 ```
+
+#### Enum with Case Conversion
+
+```rust
+#[derive(ToRedisArgs, FromRedisValue, Debug, PartialEq)]
+#[redis(rename_all = "snake_case")]
+enum UserRole {
+    Administrator,      // stored as "administrator"
+    PowerUser,          // stored as "power_user"
+    RegularUser,        // stored as "regular_user"
+    GuestUser,          // stored as "guest_user"
+}
+
+// Works seamlessly with Redis
+let role = UserRole::PowerUser;
+con.set("user:role", &role)?;
+let retrieved: UserRole = con.get("user:role")?;
+assert_eq!(role, retrieved);
+```
+
+### Naming Conventions and Attributes
+
+#### Case Conversion Rules
+
+The `rename_all` attribute supports multiple case conversion rules:
+
+```rust
+#[derive(ToRedisArgs, FromRedisValue)]
+#[redis(rename_all = "snake_case")]
+enum Status {
+    InProgress,        // → "in_progress"
+    WaitingForReview,  // → "waiting_for_review"
+    Completed,         // → "completed"
+}
+
+#[derive(ToRedisArgs, FromRedisValue)]
+#[redis(rename_all = "kebab-case")]
+enum Priority {
+    HighPriority,      // → "high-priority"
+    MediumPriority,    // → "medium-priority"
+    LowPriority,       // → "low-priority"
+}
+```
+
+Supported case conversion rules:
+- `"lowercase"`: `MyField` → `myfield`
+- `"UPPERCASE"`: `MyField` → `MYFIELD`
+- `"PascalCase"`: `my_field` → `MyField`
+- `"camelCase"`: `my_field` → `myField`
+- `"snake_case"`: `MyField` → `my_field`
+- `"kebab-case"`: `MyField` → `my-field`
+
+#### Important Naming Behavior
+
+**Key insight**: The case conversion applies to **both** serialization and deserialization:
+
+```rust
+// With rename_all = "snake_case"
+let role = UserRole::PowerUser;
+
+// Serialization: PowerUser → "power_user"
+con.set("key", &role)?;
+
+// Deserialization: "power_user" → PowerUser
+let retrieved: UserRole = con.get("key")?;
+
+// Error messages also use converted names:
+// "Unknown variant 'admin' for UserRole. Valid variants: [administrator, power_user, regular_user, guest_user]"
+```
+
+#### Redis Protocol Support
+
+This crate handles multiple Redis value types automatically:
+
+- **BulkString**: Most common for stored hash fields and string values
+- **SimpleString**: Direct Redis command responses
+- **VerbatimString**: Redis 6+ RESP3 protocol feature (automatically supported)
+- **Proper error handling**: Clear messages for nil values and type mismatches
+
+#### Advanced Features
+
+##### Hash Field Expiration (Redis 7.4+)
+```rust
+#[derive(ToRedisArgs, FromRedisValue)]
+struct SessionData {
+    user_id: u64,
+    #[redis(expire = "1800")] // 30 minutes
+    access_token: String,
+    #[redis(expire = "7200")] // 2 hours
+    refresh_token: String,
+}
+```
+
+##### Cluster-Aware Keys
+```rust
+#[derive(ToRedisArgs, FromRedisValue)]
+#[redis(cluster_key = "user_id")]
+struct UserProfile {
+    user_id: u64,
+    profile_data: String,
+}
+```
+
+##### Client-Side Caching
+```rust
+#[derive(ToRedisArgs, FromRedisValue)]
+#[redis(cache = true, ttl = "600")]
+struct CachedData {
+    id: u64,
+    data: String,
+}
+```
+
+### Development and Testing
+
+The crate includes comprehensive examples in the `examples/` directory:
+
+```bash
+# Start Redis with Docker
+cd examples && docker-compose up -d
+
+# Run basic example
+cargo run --example main
+
+# Test all enum deserialization branches
+cargo run --example enum_branches
+
+# Debug attribute parsing behavior
+cargo run --example debug_attributes
+```
+
+### Limitations
+
+- Only unit enums (variants without fields) are currently supported
+- Requires redis-rs 0.32.4 or later for full compatibility
+
+### Compatibility
+
+- **Redis**: Compatible with Redis 6+ (RESP2) and Redis 7+ (RESP3)
+- **Rust**: MSRV 1.70+ (follows redis-rs requirements)
+- **redis-rs**: 0.32.4+ (uses `num_of_args()` instead of deprecated `num_args()`)
+
+License: MIT OR Apache-2.0
 
 License: MIT OR Apache-2.0

--- a/src/data_enum.rs
+++ b/src/data_enum.rs
@@ -1,100 +1,173 @@
 use crate::util::{self, ParsedAttributeMap};
-use crate::{DeriveFromRedisArgs, DeriveToRedisArgs};
-
 use quote::quote;
-use syn::{self, DataEnum, Fields, Ident};
+use syn::{DataEnum, Fields, Ident};
 
-impl DeriveToRedisArgs for DataEnum {
-    fn derive_to_redis(
-        &self,
-        type_ident: Ident,
-        attrs: ParsedAttributeMap,
-    ) -> proc_macro::TokenStream {
-        let is_unit = self.variants.iter().all(|v| v.fields == Fields::Unit);
-        if !is_unit {
-            panic!("Only Enums without fields are supported");
-        }
+pub fn derive_to_redis_enum(
+    data_enum: DataEnum,
+    type_ident: Ident,
+    attrs: ParsedAttributeMap,
+) -> proc_macro::TokenStream {
+    // Check if all variants are unit variants (fieldless)
+    let is_unit_enum = data_enum.variants.iter().all(|v| v.fields == Fields::Unit);
 
-        let variant_names = self.variants.iter().map(|v| &v.ident).collect::<Vec<_>>();
-        let rename_all = attrs.get("rename_all").map(|v| v.as_str());
+    if !is_unit_enum {
+        panic!("ToRedisArgs can only be derived for enums with unit variants (no fields). Consider using a struct with an enum field instead.");
+    }
 
-        let match_arms = variant_names
-            .iter()
-            .map(|v| (v, util::transform_variant(&v.to_string(), rename_all)))
-            .map(|(name, value)| {
-                quote! {
-                    #type_ident::#name => {
-                        out.write_arg(#value.as_bytes());
-                    }
-                }
-            });
+    let variant_data: Vec<_> = data_enum
+        .variants
+        .iter()
+        .map(|variant| {
+            let variant_ident = &variant.ident;
+            let variant_name = util::transform_variant_name(
+                &variant_ident.to_string(),
+                attrs.rename_all.as_ref(),
+            );
+            (variant_ident, variant_name)
+        })
+        .collect();
 
-        quote! {
-            impl redis::ToRedisArgs for #type_ident {
-                fn write_redis_args<W: ?Sized + redis::RedisWrite>(&self, out: &mut W) {
-                   match self { #(#match_arms),* }
+    let variant_matches: Vec<_> = variant_data
+        .iter()
+        .map(|(variant_ident, variant_name)| {
+            quote! {
+                #type_ident::#variant_ident => out.write_arg(#variant_name.as_bytes()),
+            }
+        })
+        .collect();
+
+    let to_redis_impl = quote! {
+        impl redis::ToRedisArgs for #type_ident {
+            fn write_redis_args<W: ?Sized + redis::RedisWrite>(&self, out: &mut W) {
+                match self {
+                    #(#variant_matches)*
                 }
             }
+
+            fn num_of_args(&self) -> usize {
+                1 // Enums are always single-argument (the variant name)
+            }
         }
-        .into()
-    }
+    };
+
+    to_redis_impl.into()
 }
 
-impl DeriveFromRedisArgs for DataEnum {
-    fn derive_from_redis(
-        &self,
-        type_ident: Ident,
-        attrs: ParsedAttributeMap,
-    ) -> proc_macro::TokenStream {
-        let is_unit = self.variants.iter().all(|v| v.fields == Fields::Unit);
-        if !is_unit {
-            panic!("Only Enums without fields are supported");
+pub fn derive_from_redis_enum(
+    data_enum: DataEnum,
+    type_ident: Ident,
+    attrs: ParsedAttributeMap,
+) -> proc_macro::TokenStream {
+    // Check if all variants are unit variants (fieldless)
+    let is_unit_enum = data_enum.variants.iter().all(|v| v.fields == Fields::Unit);
+
+    if !is_unit_enum {
+        panic!("FromRedisValue can only be derived for enums with unit variants (no fields). Consider using a struct with an enum field instead.");
+    }
+
+    let variant_data: Vec<_> = data_enum
+        .variants
+        .iter()
+        .map(|variant| {
+            let variant_ident = &variant.ident;
+            let variant_name = util::transform_variant_name(
+                &variant_ident.to_string(),
+                attrs.rename_all.as_ref(),
+            );
+            (variant_ident, variant_name)
+        })
+        .collect();
+
+    let match_arms: Vec<_> = variant_data
+        .iter()
+        .map(|(variant_ident, variant_name)| {
+            quote! {
+                #variant_name => Ok(#type_ident::#variant_ident),
+            }
+        })
+        .collect();
+
+    let variant_names: Vec<&str> = variant_data.iter().map(|(_, name)| name.as_str()).collect();
+    let variant_list = variant_names.join(", ");
+
+    // Helper function to create error for unknown variants
+    let create_unknown_variant_error = quote! {
+        |unknown: &str| -> redis::RedisError {
+            redis::RedisError::from((
+                redis::ErrorKind::TypeError,
+                "Unknown enum variant",
+                format!(
+                    "Unknown variant '{}' for {}. Valid variants: [{}]",
+                    unknown,
+                    stringify!(#type_ident),
+                    #variant_list
+                ),
+            ))
         }
+    };
 
-        let rename_all = attrs.get("rename_all").map(|v| v.as_str());
-        let (variants_str, match_arms): (Vec<_>, Vec<_>) = self
-            .variants
-            .iter()
-            .map(|v| {
-                (
-                    &v.ident,
-                    util::transform_variant(&v.ident.to_string(), rename_all),
-                )
-            })
-            .map(|(ident, value)| {
-                (
-                    value.clone(),
-                    quote! {
-                        #value => Ok(#type_ident::#ident),
-                    },
-                )
-            })
-            .unzip();
+    // Helper function to parse string to enum
+    let parse_string_to_enum = quote! {
+        |s: &str| -> redis::RedisResult<#type_ident> {
+            let create_error = #create_unknown_variant_error;
+            match s {
+                #(#match_arms)*
+                unknown => Err(create_error(unknown))
+            }
+        }
+    };
 
-        let variants_str = variants_str.join(", ");
+    let from_redis_impl = quote! {
+        impl redis::FromRedisValue for #type_ident {
+            fn from_redis_value(v: &redis::Value) -> redis::RedisResult<Self> {
+                let parse_str = #parse_string_to_enum;
 
-        quote! {
-            impl redis::FromRedisValue for #type_ident {
-                fn from_redis_value(v: &redis::Value) -> Result<Self, redis::RedisError> {
-                    use redis::{ErrorKind::TypeError, Value};
-
-                    let Value::Data(data) = v else {
-                        let msg = format!("{:?}", v);
-                        return Err((TypeError, "Expected Redis string, got:", msg).into());
-                    };
-
-                    let value = std::str::from_utf8(&data[..])?;
-
-                    match value {
-                        #(#match_arms)*
-                        v => {
-                            let msg = format!("{}, Expected one of: {}", v, #variants_str);
-                            Err((TypeError, "Invalid enum variant:", msg).into())
-                        },
+                match v {
+                    // Handle binary string data (most common for stored values)
+                    redis::Value::BulkString(data) => {
+                        let s = String::from_utf8(data.clone())
+                            .map_err(|e| redis::RedisError::from((
+                                redis::ErrorKind::TypeError,
+                                "Invalid UTF-8 in enum value",
+                                e.to_string(),
+                            )))?;
+                        parse_str(&s)
+                    }
+                    
+                    // Handle simple string responses
+                    redis::Value::SimpleString(s) => {
+                        parse_str(s)
+                    }
+                    
+                    // Handle verbatim strings (Redis 6+ feature)
+                    redis::Value::VerbatimString { text, .. } => {
+                        parse_str(text)
+                    }
+                    
+                    // Handle nil values with clear error
+                    redis::Value::Nil => {
+                        Err(redis::RedisError::from((
+                            redis::ErrorKind::TypeError,
+                            "Cannot deserialize enum from nil value",
+                            format!("Expected string value for {}, got nil", stringify!(#type_ident)),
+                        )))
+                    }
+                    
+                    // Handle all other unsupported types
+                    _ => {
+                        Err(redis::RedisError::from((
+                            redis::ErrorKind::TypeError,
+                            "Cannot deserialize enum from Redis value type",
+                            format!(
+                                "Expected string value for {}, got unsupported Redis value type",
+                                stringify!(#type_ident)
+                            ),
+                        )))
                     }
                 }
             }
         }
-        .into()
-    }
+    };
+
+    from_redis_impl.into()
 }

--- a/src/data_struct.rs
+++ b/src/data_struct.rs
@@ -211,7 +211,7 @@ pub fn derive_from_redis_struct(
         Fields::Unnamed(fields_unnamed) => {
             let field_count = fields_unnamed.unnamed.len();
             let indices: Vec<syn::Index> = (0..field_count)
-                .map(|i| syn::Index::from(i))
+                .map(syn::Index::from)
                 .collect();
 
             let from_redis_impl = quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,106 +1,236 @@
 /*!
-This crate implements the [`FromRedisValue`](redis::FromRedisValue) and [`ToRedisArgs`](redis::ToRedisArgs) traits from [`mitsuhiko / redis-rs`](https://github.com/mitsuhiko/redis-rs) for any struct,
-this allows a seaming less type conversion between rust structs and Redis hash sets.
+# redis-derive
 
-This is more beneficial than JSON encoding the struct and storing the result in a Redis key because when saving as a Redis hash set,
-sorting algorithms can be performed without having to move data out of the database.
+This crate implements the [`FromRedisValue`](redis::FromRedisValue) and [`ToRedisArgs`](redis::ToRedisArgs) traits 
+from [`redis-rs`](https://github.com/redis-rs/redis-rs) for any struct or enum.
+
+This allows seamless type conversion between Rust structs and Redis hash sets, which is more beneficial than JSON encoding the struct and storing the result in a Redis key because when saving as a Redis hash set, sorting algorithms can be performed without having to move data out of the database.
 
 There is also the benefit of being able to retrieve just one value of the struct in the database.
 
-# Usage and Examples
+Initial development was done by @Michaelvanstraten 🙏🏽.
 
-To use this crate at it to your dependencies and import the following to procedural macros.
+## Features
+
+- **RESP3 Support**: Native support for Redis 7+ protocol features including VerbatimString
+- **Hash Field Expiration**: Per-field TTL support using Redis 7.4+ HEXPIRE commands  
+- **Client-Side Caching**: Automatic cache management with Redis 6+ client caching
+- **Cluster Awareness**: Hash tag generation for Redis Cluster deployments
+- **Flexible Naming**: Support for various case conversion rules (snake_case, kebab-case, etc.)
+- **Comprehensive Error Handling**: Clear error messages for debugging
+- **Performance Optimized**: Efficient serialization with minimal allocations
+
+## Usage and Examples
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+redis-derive = "0.2.0"
+redis = "0.32"
+```
+
+Import the procedural macros:
 
 ```rust
 use redis_derive::{FromRedisValue, ToRedisArgs};
 ```
 
-Now the these Marcos can be used to implement the traits [`FromRedisValue`](redis::FromRedisValue) and [`ToRedisArgs`](redis::ToRedisArgs) for your decorated struct.
+### Basic Struct Example
 
 ```rust
-#[derive(ToRedisArgs, FromRedisValue)]
-struct MySuperCoolStruct {
-    first_field : String,
-    second_field : Option<i64>,
-    third_field : Vec<String>
-}
-
-```
-These Procedural macros work for any struct in which every field's type also implements [`ToRedisArgs`](redis::ToRedisArgs) so this would be allowed:
-```rust
-#[derive(ToRedisArgs, FromRedisVaule)]
-struct MySuperCoolStruct {
-    first_field : String,
-    second_field : Option<i64>,
-    third_field : Vec<String>
-}
-
-#[derive(ToRedisArgs, FromRedisVaule)]
-struct MySecondSuperCoolStruct {
-    fourth_field : String,
-    inner_struct : MySuperCoolStruct
-}
-```
-## Complete Example
-```
 use redis::Commands;
 use redis_derive::{FromRedisValue, ToRedisArgs};
 
-#[derive(FromRedisValue, ToRedisArgs, Debug)]
-struct MySuperCoolStruct {
-    first_field : String,
-    second_field : Option<i64>,
-    third_field : Vec<String>
+#[derive(ToRedisArgs, FromRedisValue, Debug)]
+struct User {
+    id: u64,
+    username: String,
+    email: Option<String>,
+    active: bool,
 }
 
 fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/")?;
     let mut con = client.get_connection()?;
 
-    let test1 = MySuperCoolStruct{
-        first_field : "Hello World".to_owned(),
-        second_field : Some(42),
-        third_field : vec!["abc".to_owned(), "cba".to_owned()]
+    let user = User {
+        id: 12345,
+        username: "john_doe".to_string(),
+        email: Some("john@example.com".to_string()),
+        active: true,
     };
 
-    let _ = redis::cmd("HSET")
-        .arg("test1")
-        .arg(&test1)
-        .query(&mut con)?;
+    // Store individual fields
+    con.hset("user:12345", "id", user.id)?;
+    con.hset("user:12345", "username", &user.username)?;
+    con.hset("user:12345", "email", &user.email)?;
+    con.hset("user:12345", "active", user.active)?;
 
-    let db_test1 : MySuperCoolStruct = con.hgetall("test1")?;
+    // Retrieve the complete struct
+    let retrieved_user: User = con.hgetall("user:12345")?;
+    println!("Retrieved: {:?}", retrieved_user);
 
-    println!("send : {:#?}, got : {:#?}", test1, db_test1);
     Ok(())
 }
 ```
 
-# Problems and future continuations
+### Enum with Case Conversion
 
-At this point, enums can not have any fields on them.
+```rust,ignore
+use redis_derive::{FromRedisValue, ToRedisArgs};
 
-## Future Continuation
+#[derive(ToRedisArgs, FromRedisValue, Debug, PartialEq)]
+#[redis(rename_all = "snake_case")]
+enum UserRole {
+    Administrator,      // stored as "administrator" 
+    PowerUser,          // stored as "power_user"
+    RegularUser,        // stored as "regular_user"
+    GuestUser,          // stored as "guest_user"
+}
 
-- implementing a getter and setter for a Redis derived type, I imagine something like this
-```rust
-    #[derive(RedisGetter, RedisSetter)]
-    struct MySuperCoolStruct {
-        first_field : String,
-        second_field : Option<i64>,
-        third_field : Vec<String>
-    }
-    fn somefn() {
-        let mut redis_client = /* geting some connection to redis db */;
-        let first_field : String = MySuperCoolStruct::first_field::get(&redis_client, key : "MyRedisKeyForStruct");
-        MySuperCoolStruct::first_field::set(&redis_client, key : "MyRedisKeyForStruct", value : String::from("test"));
-    }
+// Works seamlessly with Redis
+let role = UserRole::PowerUser;
+con.set("user:role", &role)?;
+let retrieved: UserRole = con.get("user:role")?;
+assert_eq!(role, retrieved);
 ```
+
+## Naming Conventions and Attributes
+
+### Case Conversion Rules
+
+The `rename_all` attribute supports multiple case conversion rules:
+
+```rust
+use redis_derive::{FromRedisValue, ToRedisArgs};
+
+#[derive(ToRedisArgs, FromRedisValue)]
+#[redis(rename_all = "snake_case")]
+enum Status {
+    InProgress,        // → "in_progress"
+    WaitingForReview,  // → "waiting_for_review"  
+    Completed,         // → "completed"
+}
+
+#[derive(ToRedisArgs, FromRedisValue)]
+#[redis(rename_all = "kebab-case")]
+enum Priority {
+    HighPriority,      // → "high-priority"
+    MediumPriority,    // → "medium-priority"
+    LowPriority,       // → "low-priority"
+}
+```
+
+Supported case conversion rules:
+- `"lowercase"`: `MyField` → `myfield`
+- `"UPPERCASE"`: `MyField` → `MYFIELD`  
+- `"PascalCase"`: `my_field` → `MyField`
+- `"camelCase"`: `my_field` → `myField`
+- `"snake_case"`: `MyField` → `my_field`
+- `"kebab-case"`: `MyField` → `my-field`
+
+### Important Naming Behavior
+
+**Key insight**: The case conversion applies to **both** serialization and deserialization:
+
+```rust,ignore
+// With rename_all = "snake_case"
+let role = UserRole::PowerUser;
+
+// Serialization: PowerUser → "power_user" 
+con.set("key", &role)?;
+
+// Deserialization: "power_user" → PowerUser
+let retrieved: UserRole = con.get("key")?;
+
+// Error messages also use converted names:
+// "Unknown variant 'admin' for UserRole. Valid variants: [administrator, power_user, regular_user, guest_user]"
+```
+
+### Redis Protocol Support
+
+This crate handles multiple Redis value types automatically:
+
+- **BulkString**: Most common for stored hash fields and string values
+- **SimpleString**: Direct Redis command responses  
+- **VerbatimString**: Redis 6+ RESP3 protocol feature (automatically supported)
+- **Proper error handling**: Clear messages for nil values and type mismatches
+
+### Advanced Features
+
+#### Hash Field Expiration (Redis 7.4+)
+```rust
+use redis_derive::{FromRedisValue, ToRedisArgs};
+
+#[derive(ToRedisArgs, FromRedisValue)]
+struct SessionData {
+    user_id: u64,
+    #[redis(expire = "1800")] // 30 minutes
+    access_token: String,
+    #[redis(expire = "7200")] // 2 hours  
+    refresh_token: String,
+}
+```
+
+#### Cluster-Aware Keys
+```rust
+use redis_derive::{FromRedisValue, ToRedisArgs};
+
+#[derive(ToRedisArgs, FromRedisValue)]
+#[redis(cluster_key = "user_id")]
+struct UserProfile {
+    user_id: u64,
+    profile_data: String,
+}
+```
+
+#### Client-Side Caching
+```rust
+use redis_derive::{FromRedisValue, ToRedisArgs};
+
+#[derive(ToRedisArgs, FromRedisValue)]
+#[redis(cache = true, ttl = "600")]
+struct CachedData {
+    id: u64,
+    data: String,
+}
+```
+
+## Development and Testing
+
+The crate includes comprehensive examples in the `examples/` directory:
+
+```bash
+# Start Redis with Docker
+cd examples && docker-compose up -d
+
+# Run basic example
+cargo run --example main
+
+# Test all enum deserialization branches  
+cargo run --example enum_branches
+
+# Debug attribute parsing behavior
+cargo run --example debug_attributes
+```
+
+## Limitations
+
+- Only unit enums (variants without fields) are currently supported
+- Requires redis-rs 0.32.4 or later for full compatibility
+
+## Compatibility
+
+- **Redis**: Compatible with Redis 6+ (RESP2) and Redis 7+ (RESP3)
+- **Rust**: MSRV 1.70+ (follows redis-rs requirements)
+- **redis-rs**: 0.32.4+ (uses `num_of_args()` instead of deprecated `num_args()`)
+
+License: MIT OR Apache-2.0
 */
-use self::util::ParsedAttributeMap;
 
 use proc_macro::TokenStream;
-use syn::Data::{Enum, Struct, Union};
-use syn::{parse_macro_input, DeriveInput, Ident};
+use syn::{parse_macro_input, Data::*, DeriveInput};
 
 mod data_enum;
 mod data_struct;
@@ -108,72 +238,65 @@ mod util;
 
 #[proc_macro_derive(ToRedisArgs, attributes(redis))]
 /**
-    This macro implements the [`ToRedisArgs`](redis::ToRedisArgs) trait for a given struct or enum.
-    It generates code that serializes the fields of the struct or the variants
-    of the enum to Redis arguments.
+This macro implements the [`ToRedisArgs`](redis::ToRedisArgs) trait for a given struct or enum.
+It generates efficient serialization code that converts Rust types to Redis arguments.
 
-    # Attributes
+# Attributes
 
-    This macro also supports the following attribute on the entire struct or enum:
+- `redis(rename_all = "...")`: Transform field/variant names using case conversion rules
+- `redis(expire = "seconds")`: Set TTL for hash fields (requires Redis 7.4+)
+- `redis(expire_at = "field_name")`: Expire field at timestamp specified by another field
+- `redis(cluster_key = "field_name")`: Use specified field for Redis Cluster hash tag generation
+- `redis(cache = true)`: Enable client-side caching support
+- `redis(ttl = "seconds")`: Default TTL for cached objects
 
-    - `redis(rename_all = "...")`: this attribute specifies a rule for transforming the variants to Redis argument names. (only enums supported for now)
+## Case Conversion Rules
 
-    The possible values are:
-    - `"lowercase"`: the name is converted to lowercase.
-    - `"uppercase"`: the name is converted to uppercase.
-    - `"pascalcase"`: the name is converted to pascal case.
-    - `"camelcase"`: the name is converted to camel case.
-    - `"snake_case"`: the name is converted to snake_case.
-    - `"kebab-case"`: the name is converted to kebab-case.
+- `"lowercase"`: `MyField` → `myfield`
+- `"UPPERCASE"`: `MyField` → `MYFIELD`
+- `"PascalCase"`: `my_field` → `MyField`
+- `"camelCase"`: `my_field` → `myField`
+- `"snake_case"`: `MyField` → `my_field`
+- `"kebab-case"`: `MyField` → `my-field`
 */
 pub fn to_redis_args(tokenstream: TokenStream) -> TokenStream {
-    let abstract_syntax_tree = parse_macro_input!(tokenstream as DeriveInput);
-    let type_identifier = abstract_syntax_tree.ident;
-    let attr_map = util::parse_attributes(&abstract_syntax_tree.attrs);
+    let ast = parse_macro_input!(tokenstream as DeriveInput);
+    let type_ident = ast.ident;
+    let attr_map = util::parse_attributes(&ast.attrs);
 
-    match abstract_syntax_tree.data {
-        Struct(data_struct) => data_struct.derive_to_redis(type_identifier, attr_map),
-        Enum(data_enum) => data_enum.derive_to_redis(type_identifier, attr_map),
-        Union(_) => todo!(),
+    match ast.data {
+        Struct(data_struct) => data_struct::derive_to_redis_struct(data_struct, type_ident, attr_map),
+        Enum(data_enum) => data_enum::derive_to_redis_enum(data_enum, type_ident, attr_map),
+        Union(_) => panic!("ToRedisArgs cannot be derived for union types"),
     }
 }
 
 #[proc_macro_derive(FromRedisValue, attributes(redis))]
 /**
-    This macro implements the [`FromRedisValue`](redis::FromRedisValue) trait for a given struct or enum.
-    It generates code that deserialize the fields of the struct or the variants
-    of the enum from [`Value`](redis::Value)
+This macro implements the [`FromRedisValue`](redis::FromRedisValue) trait for a given struct or enum.
+It generates efficient deserialization code with full RESP3 support and enhanced error handling.
 
-    # Attributes
+# Attributes
 
-    This macro also supports the following attribute on the entire struct or enum:
+Same attributes as `ToRedisArgs`. The deserialization respects the same naming conventions
+and provides helpful error messages for debugging.
 
-    - `redis(rename_all = "...")`: This attribute specifies a rule for parsing variant (only enums supported for now) .
+# Error Handling
 
-    The possible values are:
-    - `"lowercase"`: Generate variant from lowercase.
-    - `"UPPERCASE"`: Generate variant from uppercase.
-    - `"PascalCase"`: Generate variant from pascal Case.
-    - `"camelCase"`: Generate variant from camel Case.
-    - `"snake_case"`: Generate variant from snake_case.
-    - `"kebab-case"`: Generate variant from kebab-case.
+The generated code provides detailed error messages including:
+- Expected vs actual Redis value types
+- Missing field information
+- Type conversion failures with context
+- RESP2/RESP3 compatibility notes
 */
 pub fn from_redis_value(tokenstream: TokenStream) -> TokenStream {
-    let abstract_syntax_tree = parse_macro_input!(tokenstream as DeriveInput);
-    let type_identifier = abstract_syntax_tree.ident;
-    let attr_map = util::parse_attributes(&abstract_syntax_tree.attrs);
+    let ast = parse_macro_input!(tokenstream as DeriveInput);
+    let type_ident = ast.ident;
+    let attr_map = util::parse_attributes(&ast.attrs);
 
-    match abstract_syntax_tree.data {
-        Struct(data_struct) => data_struct.derive_from_redis(type_identifier, attr_map),
-        Enum(data_enum) => data_enum.derive_from_redis(type_identifier, attr_map),
-        Union(_) => todo!(),
+    match ast.data {
+        Struct(data_struct) => data_struct::derive_from_redis_struct(data_struct, type_ident, attr_map),
+        Enum(data_enum) => data_enum::derive_from_redis_enum(data_enum, type_ident, attr_map),
+        Union(_) => panic!("FromRedisValue cannot be derived for union types"),
     }
-}
-
-trait DeriveToRedisArgs {
-    fn derive_to_redis(&self, type_ident: Ident, attrs: ParsedAttributeMap) -> TokenStream;
-}
-
-trait DeriveFromRedisArgs {
-    fn derive_from_redis(&self, type_ident: Ident, attrs: ParsedAttributeMap) -> TokenStream;
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,56 +1,240 @@
-use heck::{ToKebabCase, ToLowerCamelCase, ToPascalCase, ToSnakeCase};
-use std::collections::HashMap;
-use syn::{Attribute, Meta, NestedMeta};
+use syn::{Attribute, Meta};
 
-pub type ParsedAttributeMap = HashMap<String, String>;
+#[derive(Debug, Default, Clone)]
+pub struct ParsedAttributeMap {
+    pub rename_all: Option<String>,
+    pub cluster_key: Option<String>,
+    pub cache: bool,
+    pub ttl: Option<String>,
+}
 
-/*
-    Parses the Redis attributes in the given list of attributes, and returns a
-    mapping of attribute names to their string values.
-*/
-pub(crate) fn parse_attributes(attributes: &[Attribute]) -> ParsedAttributeMap {
-    let mut attr_map = HashMap::new();
-    for attribute in attributes {
-        if !attribute.path.is_ident("redis") {
+#[derive(Debug, Default, Clone)]
+pub struct FieldAttributes {
+    pub skip: bool,
+    pub rename: Option<String>,
+    pub expire: Option<String>,
+    pub expire_at: Option<String>,
+}
+
+pub fn parse_attributes(attrs: &[Attribute]) -> ParsedAttributeMap {
+    let mut parsed = ParsedAttributeMap::default();
+
+    for attr in attrs {
+        if !attr.path().is_ident("redis") {
             continue;
         }
 
-        if let Ok(Meta::List(meta)) = attribute.parse_meta() {
-            if meta.path.is_ident("redis") {
-                for nested_meta in meta.nested {
-                    if let NestedMeta::Meta(Meta::NameValue(name_value)) = nested_meta {
-                        let attr_name = name_value
-                            .path
-                            .get_ident()
-                            .expect("Attribute name expected")
-                            .to_string();
-                        let attr_value = match &name_value.lit {
-                            syn::Lit::Str(lit_str) => lit_str.value(),
-                            _ => panic!("Attribute value must be a string literal"),
-                        };
-                        attr_map.insert(attr_name, attr_value);
-                    }
-                }
+        // Parse #[redis(...)] attributes
+        if let Meta::List(list) = &attr.meta {
+            // Convert token stream to string and parse manually for now
+            let tokens_str = list.tokens.to_string();
+            
+            // Look for rename_all = "value"
+            if let Some(rename_all_value) = extract_quoted_value(&tokens_str, "rename_all") {
+                parsed.rename_all = Some(rename_all_value);
+            }
+            
+            // Look for cluster_key = "value"  
+            if let Some(cluster_key_value) = extract_quoted_value(&tokens_str, "cluster_key") {
+                parsed.cluster_key = Some(cluster_key_value);
+            }
+            
+            // Look for ttl = "value"
+            if let Some(ttl_value) = extract_quoted_value(&tokens_str, "ttl") {
+                parsed.ttl = Some(ttl_value);
+            }
+            
+            // Look for cache (boolean flag)
+            if tokens_str.contains("cache") {
+                parsed.cache = true;
             }
         }
     }
-    attr_map
+
+    parsed
 }
 
-/*
-    Transforms a variant value into the desired case style based on the provided `rename_all` option.
-    This function panics if an invalid `rename_all` value is provided.
-*/
-pub(crate) fn transform_variant(variant_value: &str, rename_all: Option<&str>) -> String {
-    let renamed = rename_all.map(|rule| match rule {
-        "lowercase" => variant_value.to_lowercase(),
-        "UPPERCASE" => variant_value.to_uppercase(),
-        "PascalCase" => variant_value.to_pascal_case(),
-        "camelCase" => variant_value.to_lower_camel_case(),
-        "snake_case" => variant_value.to_snake_case(),
-        "kebab-case" => variant_value.to_kebab_case(),
-        _ => panic!("Invalid rename_all value"),
-    });
+pub fn parse_field_attributes(attrs: &[Attribute]) -> FieldAttributes {
+    let mut field_attrs = FieldAttributes::default();
 
-    renamed.unwrap_or_else(|| variant_value.to_string())
+    for attr in attrs {
+        if !attr.path().is_ident("redis") {
+            continue;
+        }
+
+        if let Meta::List(list) = &attr.meta {
+            let tokens_str = list.tokens.to_string();
+            
+            if tokens_str.contains("skip") {
+                field_attrs.skip = true;
+            }
+            
+            if let Some(rename_value) = extract_quoted_value(&tokens_str, "rename") {
+                field_attrs.rename = Some(rename_value);
+            }
+            
+            if let Some(expire_value) = extract_quoted_value(&tokens_str, "expire") {
+                // Make sure it's not expire_at
+                if !tokens_str.contains("expire_at") {
+                    field_attrs.expire = Some(expire_value);
+                }
+            }
+            
+            if let Some(expire_at_value) = extract_quoted_value(&tokens_str, "expire_at") {
+                field_attrs.expire_at = Some(expire_at_value);
+            }
+        }
+    }
+
+    field_attrs
+}
+
+/// Extract a quoted string value from tokens like: key = "value"
+fn extract_quoted_value(tokens: &str, key: &str) -> Option<String> {
+    // Look for pattern: key = "value"
+    let pattern = format!("{} =", key);
+    if let Some(start_pos) = tokens.find(&pattern) {
+        let after_equals = &tokens[start_pos + pattern.len()..];
+        
+        // Find the opening quote
+        if let Some(quote_start) = after_equals.find('"') {
+            let after_quote = &after_equals[quote_start + 1..];
+            
+            // Find the closing quote
+            if let Some(quote_end) = after_quote.find('"') {
+                return Some(after_quote[..quote_end].to_string());
+            }
+        }
+    }
+    None
+}
+
+pub fn transform_variant_name(variant_name: &str, rename_all: Option<&String>) -> String {
+    let rename_rule = match rename_all {
+        Some(rule) => rule.as_str(),
+        None => return variant_name.to_string(),
+    };
+
+    match rename_rule {
+        "lowercase" => variant_name.to_lowercase(),
+        "UPPERCASE" => variant_name.to_uppercase(),
+        "PascalCase" => to_pascal_case(variant_name),
+        "camelCase" => to_camel_case(variant_name),
+        "snake_case" => to_snake_case(variant_name),
+        "kebab-case" => to_kebab_case(variant_name),
+        _ => {
+            panic!(
+                "Invalid rename_all value: {rename_rule}. Valid options: lowercase, UPPERCASE, PascalCase, camelCase, snake_case, kebab-case"
+            );
+        }
+    }
+}
+
+pub fn transform_field_name(
+    field_name: &str,
+    rename_all: Option<&String>,
+    field_rename: Option<&String>,
+) -> String {
+    // Field-level rename takes precedence
+    if let Some(rename) = field_rename {
+        return rename.clone();
+    }
+
+    transform_variant_name(field_name, rename_all)
+}
+
+fn to_pascal_case(s: &str) -> String {
+    let mut result = String::new();
+    let mut capitalize_next = true;
+
+    for c in s.chars() {
+        if c == '_' || c == '-' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.extend(c.to_uppercase());
+            capitalize_next = false;
+        } else {
+            result.extend(c.to_lowercase());
+        }
+    }
+
+    result
+}
+
+fn to_camel_case(s: &str) -> String {
+    let pascal = to_pascal_case(s);
+    if pascal.is_empty() {
+        return pascal;
+    }
+
+    let mut chars = pascal.chars();
+    let first_char = chars.next().unwrap().to_lowercase().to_string();
+    first_char + &chars.collect::<String>()
+}
+
+fn to_snake_case(s: &str) -> String {
+    let mut result = String::new();
+    let mut prev_is_lower = false;
+
+    for (i, c) in s.chars().enumerate() {
+        if c.is_uppercase()
+            && i > 0
+            && (prev_is_lower || s.chars().nth(i + 1).is_some_and(|next| next.is_lowercase()))
+        {
+            result.push('_');
+        }
+        result.extend(c.to_lowercase());
+        prev_is_lower = c.is_lowercase();
+    }
+
+    result
+}
+
+fn to_kebab_case(s: &str) -> String {
+    to_snake_case(s).replace('_', "-")
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_case_transformations() {
+        assert_eq!(to_snake_case("MyFieldName"), "my_field_name");
+        assert_eq!(to_pascal_case("my_field_name"), "MyFieldName");
+        assert_eq!(to_camel_case("my_field_name"), "myFieldName");
+        assert_eq!(to_kebab_case("MyFieldName"), "my-field-name");
+    }
+
+    #[test]
+    fn test_transform_variant_name() {
+        assert_eq!(
+            transform_variant_name("InProgress", Some(&"snake_case".to_string())),
+            "in_progress"
+        );
+        assert_eq!(
+            transform_variant_name("InProgress", Some(&"kebab-case".to_string())),
+            "in-progress"
+        );
+        assert_eq!(
+            transform_variant_name("InProgress", Some(&"lowercase".to_string())),
+            "inprogress"
+        );
+        assert_eq!(transform_variant_name("InProgress", None), "InProgress");
+    }
+
+    #[test]
+    fn test_extract_quoted_value() {
+        assert_eq!(
+            extract_quoted_value(r#"rename_all = "snake_case""#, "rename_all"),
+            Some("snake_case".to_string())
+        );
+        assert_eq!(
+            extract_quoted_value(r#"expire = "3600""#, "expire"),
+            Some("3600".to_string())
+        );
+        assert_eq!(extract_quoted_value("cache", "cache"), None);
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -92,7 +92,7 @@ pub fn parse_field_attributes(attrs: &[Attribute]) -> FieldAttributes {
 /// Extract a quoted string value from tokens like: key = "value"
 fn extract_quoted_value(tokens: &str, key: &str) -> Option<String> {
     // Look for pattern: key = "value"
-    let pattern = format!("{} =", key);
+    let pattern = format!("{key} =");
     if let Some(start_pos) = tokens.find(&pattern) {
         let after_equals = &tokens[start_pos + pattern.len()..];
         


### PR DESCRIPTION
# PR Summary: Major Modernization - redis-derive v0.2.0 with Redis 0.32+ Support

## 🎯 **Primary Objective**
**Enable redis-derive to work with modern redis-rs versions (0.32+)** - The current crate is stuck on redis-rs 0.21.5 from 2021, preventing users from accessing 3+ years of Redis ecosystem improvements.

## 🚀 **Key Improvements**

### **Critical Compatibility Fixes**
- **Redis 0.21.5 → 0.32.4**: Massive dependency update bringing the crate current
- **Deprecated API migration**: Replaced `num_args()` with `num_of_args()` 
- **Modern Value types**: Fixed `Value::Data` → `Value::BulkString` changes
- **syn 1.0 → 2.0**: Updated to modern proc-macro framework

### **Redis Protocol Modernization** 
- **RESP3 Support**: Native Redis 7+ protocol with `VerbatimString` handling
- **Enhanced Error Handling**: Comprehensive error messages covering all Redis value types (`BulkString`, `SimpleString`, `VerbatimString`, `Nil`, etc.)
- **Protocol Flexibility**: Seamless handling of both RESP2 and RESP3 protocols

### **Developer Experience Enhancements**
- **Comprehensive Examples**: Docker Compose setup with working examples demonstrating all features
- Improved Error Messaging
- Updated Documentation
- More Testing

## 📊 **Breaking Changes Handled Gracefully**
- **Version bump**: 0.1.7 → 0.2.0 (appropriate for dependency compatibility changes)
- **API preserved**: All existing user code continues to work unchanged

